### PR TITLE
Update bytetracker example

### DIFF
--- a/runtime/hailo-8/python/detection_with_tracker/README.md
+++ b/runtime/hailo-8/python/detection_with_tracker/README.md
@@ -10,53 +10,62 @@ Requirements
 ------------
 
 - hailo_platform==4.18.0
-- ByteTracker
+- Roboflow supervision
 - OpenCV (cv2)
 - tqdm
-- supervision
+
+Note: Roboflow supervision ships ByteTracker already. Thus, you needn't install bytetracker
 
 Supported Models
 ----------------
 
-This example expects the hef to contain HailoRT-Postprocess. Because of that, this example only supports detections models that allow hailort-postprocess:
+This example expects the HEF model to contain HailoRT-Postprocess. Because of that, this example only supports detections models that allow hailort-postprocess:
 - yolov5/6/7/8
 - yolox
 - ssd
 - centernet
  
-
 Usage
 -----
 
-0. Install PyHailoRT
+0. Create a virtualenv
+    ```shell script
+    python -m venv .venv
+    source .venv/bin/activate
+    ```
+
+1. Install PyHailoRT
     - Download the HailoRT whl from the Hailo website - make sure to select the correct Python version. 
     - Install whl:
         ```shell script
         pip install hailort-X.X.X-cpXX-cpXX-linux_x86_64.whl
         ```
 
-1. Clone the repository:
+2. Clone the repository:
     ```shell script
-    git clone <https://github.com/hailo-ai/Hailo-Application-Code-Examples.git>
+    git clone https://github.com/hailo-ai/Hailo-Application-Code-Examples.git
         
-    cd Hailo-Application-Code-Examples/runtime/python/detection_with_tracker
+    cd Hailo-Application-Code-Examples/runtime/hailo-8/python/detection_with_tracker/
     ```
 
-2. Install dependencies:
+3. Install dependencies:
     ```shell script
     pip install -r requirements.txt
     ```
 
-
-3. Download example files:
+4. Download example files:
     ```shell script
     ./download_resources.sh
     ```
 
-4. Run the script:
+5. Run the script:
     ```shell script
     ./object_detection_tracking.py -n <net> -i <input_video> -o <output_video> -l <labels> -s <score_thresh>
     ```
+
+As a result, the program will perform the detection/tracking of objects in the video file, generating the output video in the same directory:
+
+![image](https://github.com/user-attachments/assets/1b7fe0ab-eb73-4f47-b493-ec17832931a9)
 
 Arguments
 ---------
@@ -75,14 +84,14 @@ Example
 -------
 **Command**
 ```shell script
-./detection_with_tracker.py -i input_video.mp4 -o output_video.mp4 -l coco.txt -s 0.5
+./detection_with_tracker.py -n yolov5m_wo_spp_60p.hef -i input_video.mp4 -o output_video.mp4 -l coco.txt -s 0.5
 ```
 
 Additional Notes
 ----------------
 
-- The example was only tested with ``HailoRT v4.18.0``
-- The example expects a HEF which contains the HailoRT Postprocess
+- The example was only tested with `HailoRT v4.18.0` and `HailoRT v4.21.0`
+- The example expects a HEF model file which contains the HailoRT Postprocess
 - The script assumes that the input video is in a standard format supported by OpenCV (e.g., .mp4, .avi).
 
 Disclaimer

--- a/runtime/hailo-8/python/detection_with_tracker/requirements.txt
+++ b/runtime/hailo-8/python/detection_with_tracker/requirements.txt
@@ -1,4 +1,4 @@
-bytetracker
+cython
 supervision==0.25.1
 loguru
 tqdm


### PR DESCRIPTION
This PR updates the instructions to run the detection_with_tracker example on Raspberry Pi Bookworm/Python 3.11.

It turns out that [pypi ByteTracker does not support Python 3.11 yet](https://pypi.org/project/bytetracker/). However, ByteTracker needn't be installed since it is already part of [Roboflow supervision dependency](https://supervision.roboflow.com/trackers/).

Thus, avoiding the installation of ByteTracker makes it easier to run the example because of the chain of compatibility issues between onnxruntime, onnx, ByteTracker, and Python 3.11. 

Also note that 3.11 is the official Python version shipped in Raspberry Pi Bookworm OS.

This PR fix https://github.com/hailo-ai/Hailo-Application-Code-Examples/issues/322